### PR TITLE
Connection bugs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ run.bat
 uPyLoader.lnk
 dist/*
 *.exe
+*.swp


### PR DESCRIPTION
This is some minor clean up for some connection error cases.  First off, I added a new "connecting..." state (blue color) to show the user something is in progress.  Then I fixed the error cases (compile error, mpy file attempting to be compiled, or connection to valid COM port that is connected but NOT to a real device) and made the execution avoid trying to auto transfer any files (if auto transfer was selected) or from checking if the init scripts are valid in the case that you're not connected to a valid COM device.  

I also added some port refresh commands which are nice if you have a preferred port set.  They will update the com port to the preferred port if it exists and you fell into an error case. 

And I updated .gitignore for my .swp vim files