### PR TITLE
Setting file permission

### DIFF
--- a/src/setting.py
+++ b/src/setting.py
@@ -1,6 +1,7 @@
 from PyQt5.QtCore import QByteArray
 from PyQt5.QtCore import QDir
 import json
+import os
 
 from PyQt5.QtCore import Qt
 from PyQt5.QtGui import QKeySequence
@@ -106,7 +107,7 @@ class Settings(metaclass=Singleton):
 
     def save(self):
         try:
-            with open("config.json", "r+") as file:
+            with open(os.open('config.json', os.O_WRONLY | os.O_TRUNC), 'w') as file:
                 json.dump(self.serialize(), file)
         except IOError:
             pass

--- a/src/setting.py
+++ b/src/setting.py
@@ -106,7 +106,7 @@ class Settings(metaclass=Singleton):
 
     def save(self):
         try:
-            with open("config.json", "w") as file:
+            with open("config.json", "r+") as file:
                 json.dump(self.serialize(), file)
         except IOError:
             pass


### PR DESCRIPTION
This is just a small fix to allow for the config.json file to be set to "hidden" in windows and still allow upyloader to overwrite the file.  Using open with mode 'r' gives a permission error, but per this stack overflow you can see that using r+ works.  But r+ didn't zero out the file so that's why I used the other options to open and truncate seen in this change.  

https://stackoverflow.com/questions/46592650/why-does-setting-the-hidden-file-attribute-on-a-file-make-it-read-only-for-pyt?noredirect=1#comment80141829_46592650