### PR TITLE
Fix bug with python 3.x

### DIFF
--- a/src/gui/file_transfer_dialog.py
+++ b/src/gui/file_transfer_dialog.py
@@ -47,7 +47,7 @@ class FileTransferDialog(QDialog, Ui_FileTransferDialog):
             sleep(0.5)
             self.accept()
         else:
-            self.progressBar.setValue(self._transfer.progress * 100)
+            self.progressBar.setValue(int(self._transfer.progress * 100))
 
     @property
     def transfer(self):


### PR DESCRIPTION
With Python 3.x file transfer crash:
TypeError: setValue(self, value: int): argument 1 has unexpected type 'float'